### PR TITLE
Corrige seletor para contemplar apenas transacoes

### DIFF
--- a/content.js
+++ b/content.js
@@ -11,16 +11,14 @@ chrome.runtime.onMessage.addListener(
 
 function getData() {
   var result = [["categoria", "loja", "valor", "data"]];
-  var a = document.querySelectorAll("div.event-card")
+  var a = document.querySelectorAll("div.event-card.transaction")
   for (var i = 0; i < a.length; i++) {
     console.log(i);
     var categoria = a[i].querySelector("span.title").textContent;
-    if (categoria != "Fatura paga") {
-      var loja = a[i].querySelector("h4.description").textContent;
-      var valor = a[i].querySelector("div.amount").textContent.replace(/[^0-9-,]/g, '').replace(",",".");
-      var data = a[i].querySelector("span.time").textContent;
-      result.push([categoria, loja, valor, data]);
-    }
+    var loja = a[i].querySelector("h4.description").textContent;
+    var valor = a[i].querySelector("div.amount").textContent.replace(/[^0-9-,]/g, '').replace(",",".");
+    var data = a[i].querySelector("span.time").textContent;
+    result.push([categoria, loja, valor, data]);
   }
   var csvContent = "data:text/csv;charset=utf-8,";
   result.forEach(function(infoArray, index){


### PR DESCRIPTION
Ocorriam erros na exportação quando existiam elementos que não eram
transações, tais como "Fatura fechada".

O novo seletor restringe a busca somente a transações e deixa de
fora os seguintes eventos (texto, classe):
- Fatura paga `.bill_flow_paid'`
- Fatura fechada `.bill_flow_closed'`
- Bem-vindo ao Nubank! `.welcome'`
- Limite inicial `.initial_account_limit'`
- Seu cartão está Desbloqueado `.card_activated'`
- Limite alterado `.account_limit_set'`
- Transação cancelada `.transaction_reversed'`
